### PR TITLE
fix: resolve nav link sizing issue on desktop

### DIFF
--- a/src/assets/styles/components/_navigation.css
+++ b/src/assets/styles/components/_navigation.css
@@ -64,7 +64,8 @@ a[rel="home"] {
 
     &[aria-current="page"] {
         background-color: var(--fl-bgColor, var(--color-indigo-800));
-        box-shadow: inset 0.25rem 0 0 0 var(--fl-linkFgColor, var(--color-indigo-100));
+        box-shadow: inset 0.25rem 0 0 0
+            var(--fl-linkFgColor, var(--color-indigo-100));
         color: var(--fl-linkFgColor, var(--color-white));
     }
 
@@ -98,7 +99,7 @@ a[rel="home"] {
         max-width: 75rem;
         margin-inline: auto;
     }
-    
+
     .navigation__brand {
         padding-inline: 0;
     }
@@ -120,10 +121,14 @@ a[rel="home"] {
     .navigation__link {
         block-size: 5.5rem;
         padding-inline: 1.875rem;
+        width: max-content;
 
         &[aria-current="page"] {
-            box-shadow:
-            inset 0 -0.25rem 0 0 var(--fg-linkFgColor, var(--fl-fgColor, var(--color-indigo-100)));
+            box-shadow: inset 0 -0.25rem 0 0
+                var(
+                    --fg-linkFgColor,
+                    var(--fl-fgColor, var(--color-indigo-100))
+                );
         }
 
         &:hover,


### PR DESCRIPTION
I noticed that on desktop the nav links were wrapping strangely so this PR resolves the issue.

<img width="310" alt="Screenshot of navigation bar with line wrapping" src="https://github.com/user-attachments/assets/4ae5b93f-f6d6-4edb-8732-4d5536359d69" />
