### PR TITLE
chore(deps): reconfigure renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,15 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["config:recommended"]
+    "extends": ["config:recommended"],
+    "lockFileMaintenance": {
+        "enabled": true,
+        "automerge": true
+    },
+    "packageRules": [
+        {
+            "matchUpdateTypes": ["minor", "patch"],
+            "matchCurrentVersion": "!/^0/",
+            "automerge": true
+        }
+    ]
 }


### PR DESCRIPTION
Allow renovate to auto merge minor dependency bumps as well as lock file updates. CI will still be enforced.