### PR TITLE
feat: use custom element for disclosure component

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { IdAttributePlugin, RenderPlugin } from "@11ty/eleventy";
 import eleventyNavigationPlugin from "@11ty/eleventy-navigation";
 import brokenLinksPlugin from "eleventy-plugin-broken-links";
@@ -56,14 +57,15 @@ export default function eleventy(eleventyConfig) {
         return translationUrl;
     });
 
-    eleventyConfig.addPairedShortcode("accordion", async function (content, label) {
+    eleventyConfig.addPairedShortcode("disclosure", async function (content, label) {
         const contentRenderer = await RenderPlugin.String(content, "md", {});
         const renderedContent = await contentRenderer();
+        const contentId = randomUUID();
 
-        return `<details class="accordion">
-        <summary>${label}</summary>
-        <div class="accordion__content">${renderedContent}</div>
-      </details>`;
+        return `<inclusive-disclosure>
+        <button aria-controls="${contentId}">${label}</button>
+        <div content id="${contentId}">${renderedContent}</div>
+      </inclusive-disclosure>`;
     });
 
     eleventyConfig.addTransform("parse", parse);

--- a/src/assets/scripts/app.js
+++ b/src/assets/scripts/app.js
@@ -3,3 +3,40 @@ menuButton.addEventListener("click", () => {
     const ariaExpanded = menuButton.ariaExpanded === "false";
     menuButton.ariaExpanded = ariaExpanded;
 });
+
+/**
+ * Based on code by Chris Ferdinandi, released under the MIT license.
+ * @see https://gomakethings.com/web-components-vs.-state-based-ui/
+ */
+customElements.define(
+    "inclusive-disclosure",
+    class extends HTMLElement {
+        constructor() {
+            super();
+
+            this.toggle = this.querySelector("[aria-controls]");
+            this.content = this.querySelector("[content]");
+
+            if (!this.toggle || !this.content) {
+                return;
+            }
+
+            this.toggle.removeAttribute("hidden");
+            this.toggle.setAttribute("aria-expanded", false);
+            this.content.setAttribute("hidden", "");
+
+            this.toggle.addEventListener("click", this);
+        }
+
+        handleEvent(event) {
+            event.preventDefault();
+            if (this.toggle.getAttribute("aria-expanded") === "true") {
+                this.toggle.setAttribute("aria-expanded", false);
+                this.content.setAttribute("hidden", "");
+            } else {
+                this.toggle.setAttribute("aria-expanded", true);
+                this.content.removeAttribute("hidden");
+            }
+        }
+    }
+);

--- a/src/assets/styles/app.css
+++ b/src/assets/styles/app.css
@@ -15,7 +15,7 @@
 @import "./global/_header.css";
 
 /* Components */
-@import "./components/_accordion.css";
+@import "./components/_disclosure.css";
 @import "./components/_navigation.css";
 @import "./components/_card.css";
 @import "./components/_project-panel.css";

--- a/src/assets/styles/base/_base.css
+++ b/src/assets/styles/base/_base.css
@@ -161,7 +161,7 @@ main section:last-of-type:not(:first-of-type) {
 
     a:hover img,
     a:hover:focus img,
-    a:hover:active img  {
+    a:hover:active img {
         filter: url("#brown") invert();
     }
 }
@@ -224,7 +224,7 @@ footer a:not([class]) {
 
 /* Buttons */
 
-button:not([class]),
+button:not([class]):not([aria-controls]),
 button.secondary,
 button.borderless {
     appearance: none;
@@ -243,7 +243,7 @@ button.borderless {
     }
 }
 
-button:not([class]) {
+button:not([class]):not([aria-controls]) {
     background-color: var(--fl-linkFgColor, var(--color-indigo-700));
     color: var(--fl-linkBgColor, var(--color-white));
 
@@ -257,14 +257,16 @@ button:not([class]) {
     &:active,
     &:active:hover {
         background-color: var(--fl-linkBgColor, var(--color-indigo-200));
-        box-shadow: inset 0 0 0 0.125rem var(--fl-linkFgColor, var(--color-indigo-700));
+        box-shadow: inset 0 0 0 0.125rem
+            var(--fl-linkFgColor, var(--color-indigo-700));
         color: var(--fl-linkFgColor, var(--color-indigo-700));
     }
 }
 
 button.secondary {
     background-color: var(--fl-linkBgColor, var(--color-light-grey));
-    box-shadow: inset 0 0 0 0.125rem var(--fl-linkFgColor, var(--color-indigo-700));
+    box-shadow: inset 0 0 0 0.125rem
+        var(--fl-linkFgColor, var(--color-indigo-700));
     color: var(--fl-linkFgColor, var(--color-indigo-700));
 
     &:hover,

--- a/src/assets/styles/components/_disclosure.css
+++ b/src/assets/styles/components/_disclosure.css
@@ -1,25 +1,25 @@
-.accordion {
+inclusive-disclosure {
+    display: block;
     min-height: 5rem;
     padding-inline: 0.5rem;
 }
 
-.accordion summary {
+inclusive-disclosure [aria-expanded] {
     align-items: center;
-    box-shadow: inset 0 0.125rem 0 0 var(--fl-linkFgColor, var(--color-indigo-700));
+    appearance: none;
+    background-color: inherit;
+    border: 0;
+    box-shadow: inset 0 0.125rem 0 0
+        var(--fl-linkFgColor, var(--color-indigo-700));
     color: var(--fl-linkFgColor, var(--color-indigo-700));
-    cursor: pointer;
     display: flex;
     font-family: var(--family-display);
     font-size: var(--step-2);
     font-weight: var(--font-weight-semibold);
     height: 5rem;
-    list-style-type: none;
     padding-inline-end: 0.625;
     position: relative;
-
-    &::-webkit-details-marker {
-        display: none;
-    }
+    width: 100%;
 
     &::after {
         background-color: var(--fl-linkFgColor, var(--color-indigo-700));
@@ -53,20 +53,21 @@
     }
 }
 
-.accordion[open] summary::after {
+inclusive-disclosure [aria-expanded="true"]::after {
     transform: rotate(180deg);
 }
 
-.accordion:focus-within {
+inclusive-disclosure:focus-within {
     border-radius: 0.1875rem;
-    box-shadow: inset 0 0 0 0.125rem var(--fl-linkFgColor, var(--color-indigo-700));
+    box-shadow: inset 0 0 0 0.125rem
+        var(--fl-linkFgColor, var(--color-indigo-700));
 }
 
-.accordion__content {
-    padding-block-start: 1em;
-    padding-block-end: 2.1875rem;
+inclusive-disclosure [content] {
+    padding-block: 1em;
+    margin-block-end: 2.1875rem;
 }
 
-* + .accordion {
+* + inclusive-disclosure {
     margin-block-start: 1.25rem;
 }


### PR DESCRIPTION
Replaces `<details>` with custom `<inclusive-disclosure>` element. To test, put this in a project body:

```njk
{% disclosure 'Test' %}

Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.

{% enddisclosure %}
```