### PR TITLE
fix: align project title in the center of its banner

### DIFF
--- a/src/_includes/layouts/project.njk
+++ b/src/_includes/layouts/project.njk
@@ -3,8 +3,10 @@
 {% block content %}
 <div class="project" style="--project-color: var(--fl-bgColor, var(--color-{{ color }}))">
     <div class="banner">
-        <a href="{% if lang === "en" %}/projects{% else %}/{{lang }}/{% __ 'projects' %}{% endif %}" >{% __ 'projects' %} {% include 'svg/arrowRight.svg' %}</a>
-        <h1>{{ title }}</h1>
+        <div class="text">
+            <a href="{% if lang === "en" %}/projects{% else %}/{{lang }}/{% __ 'projects' %}{% endif %}" >{% __ 'projects' %} {% include 'svg/arrowRight.svg' %}</a>
+            <h1>{{ title }}</h1>
+        </div>
         {% if previewImage and previewImageAlt %}
         <div class="image">
             <img src="{{ previewImage }}" alt="{{ previewImageAlt }}" />

--- a/src/_includes/layouts/project.njk
+++ b/src/_includes/layouts/project.njk
@@ -3,10 +3,8 @@
 {% block content %}
 <div class="project" style="--project-color: var(--fl-bgColor, var(--color-{{ color }}))">
     <div class="banner">
-        <div class="flow">
-            <a href="{% if lang === "en" %}/projects{% else %}/{{lang }}/{% __ 'projects' %}{% endif %}" >{% __ 'projects' %} {% include 'svg/arrowRight.svg' %}</a>
-            <h1>{{ title }}</h1>
-        </div>
+        <a href="{% if lang === "en" %}/projects{% else %}/{{lang }}/{% __ 'projects' %}{% endif %}" >{% __ 'projects' %} {% include 'svg/arrowRight.svg' %}</a>
+        <h1>{{ title }}</h1>
         {% if previewImage and previewImageAlt %}
         <div class="image">
             <img src="{{ previewImage }}" alt="{{ previewImageAlt }}" />

--- a/src/assets/styles/collections/_projects.css
+++ b/src/assets/styles/collections/_projects.css
@@ -126,7 +126,7 @@
             inset 0 -0.1875rem 0 0 var(--fl-fgColor, transparent);
         flex-direction: row;
         height: 39.625rem;
-        margin-block-start: unset;
+        margin-block-start: 0;
         padding-inline: 8.25rem 0;
         padding-block: 0;
     }

--- a/src/assets/styles/collections/_projects.css
+++ b/src/assets/styles/collections/_projects.css
@@ -120,14 +120,16 @@
             inset 0 -0.1875rem 0 0 var(--fl-fgColor, transparent);
         flex-direction: row;
         height: 39.625rem;
-        margin-block-start: 0;
+        align-items: center;
+        margin-block-start: unset;
         padding-inline: 8.25rem 0;
         padding-block: 0;
+        position: relative;
     }
 
-    .project .banner .flow {
-        margin-block-start: 5.5rem;
-        width: auto;
+    .project .banner a {
+        position: absolute;
+        top: 5.5rem;
     }
 
     .project .banner .image {

--- a/src/assets/styles/collections/_projects.css
+++ b/src/assets/styles/collections/_projects.css
@@ -16,6 +16,14 @@
         inset 0 -0.1875rem 0 0 var(--fl-fgColor, transparent);
 }
 
+.project .banner .text {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: center;
+    position: relative;
+}
+
 .project .banner a {
     align-items: center;
     display: flex;
@@ -113,18 +121,15 @@
 
 @media (width >= 70.875rem) {
     .project .banner {
-        align-items: flex-start;
         box-shadow:
             -75rem 0 0 0 var(--fl-fgColor, var(--project-color)),
             inset 3.5rem 0 0 0 var(--fl-fgColor, var(--project-color)),
             inset 0 -0.1875rem 0 0 var(--fl-fgColor, transparent);
         flex-direction: row;
         height: 39.625rem;
-        align-items: center;
         margin-block-start: unset;
         padding-inline: 8.25rem 0;
         padding-block: 0;
-        position: relative;
     }
 
     .project .banner a {

--- a/src/assets/styles/collections/_projects.css
+++ b/src/assets/styles/collections/_projects.css
@@ -19,7 +19,6 @@
 .project .banner .text {
     display: flex;
     flex-direction: column;
-    height: 100%;
     justify-content: center;
     position: relative;
 }


### PR DESCRIPTION
It was an issue brought up by Vera during the weekly check-in; currently project title in single project page banner leaves large space at the bottom of it, and Vera wants the title to be centred.


<img width="1398" alt="Screenshot 2025-02-14 at 12 23 00 PM" src="https://github.com/user-attachments/assets/6657739f-aefb-4ad9-a438-42bf8f648f76" />
