### PR TITLE
fix: set width for the government of Canada image link (resolves #168)

### DIFF
--- a/src/assets/styles/collections/_projects.css
+++ b/src/assets/styles/collections/_projects.css
@@ -110,7 +110,7 @@
 
 .project .content a[href^="https://www.canada.ca"] img
 {
-    max-width: 12.5rem;
+    width: 12.5rem;
 }
 
 .project .content a:has(img) {


### PR DESCRIPTION
The image link width is always set to 12.5rem, even in mobile view; use width instead of max-width.