### PR TITLE
feat: enforce URL-safe slugs

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -112,6 +112,7 @@ collections:
         i18n: true
         required: true
         hint: Use this field to customize the URL of the project. For example, if you want to display 'Regulating the Digital Domain' at `/projects/rtdd`, enter `rtdd`.
+        pattern: ['^[a-z0-9-]+$', 'Only lowercase letters, numbers and hyphens permitted']
       - label: Excerpt
         name: excerpt
         widget: text
@@ -177,6 +178,7 @@ collections:
         i18n: true
         required: true
         hint: Use this field to customize the URL of the project subpage. For example, if you want to display 'Regulating the Digital Domain reports' at `/projects/rtdd/reports/`, enter `reports`.
+        pattern: ['^[a-z0-9-]+$', 'Only lowercase letters, numbers and hyphens permitted']
       - label: Parent Project
         name: parent
         widget: relation

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -83,6 +83,7 @@ collections:
         name: body
         widget: markdown
         i18n: true
+        buttons: [bold, italic, link, heading-two, heading-three, heading-four, heading-five, heading-six, quote, bulleted-list, numbered-list]
   - label: Projects
     label_singular: Project
     name: projects
@@ -149,6 +150,7 @@ collections:
         name: body
         widget: markdown
         i18n: true
+        buttons: [bold, italic, link, heading-two, heading-three, heading-four, heading-five, heading-six, quote, bulleted-list, numbered-list]
   - label: Project Subpages
     label_singular: Project Subpage
     name: project-subpages
@@ -208,6 +210,7 @@ collections:
         name: body
         widget: markdown
         i18n: true
+        buttons: [bold, italic, link, heading-two, heading-three, heading-four, heading-five, heading-six, quote, bulleted-list, numbered-list]
   - label: Events
     label_singular: Event
     name: event
@@ -269,6 +272,7 @@ collections:
         name: body
         widget: markdown
         i18n: true
+        buttons: [bold, italic, link, heading-two, heading-three, heading-four, heading-five, heading-six, quote, bulleted-list, numbered-list]
   - label: Resources
     label_singular: Resource
     name: resources


### PR DESCRIPTION
It's currently possible to enter a slug that isn't URL-safe. This PR adds a regex validation pattern to enforce alphanumeric slugs with hyphens (no spaces or capital letters). To test, run the CMS locally, open it in Chrome, and try to add a project or subpage with an invalid slug.

This PR also removes h1 level headings from the dropdown for the markdown editor.