### PR TITLE
fix: fix some UI issues on resources page filter

### DIFF
--- a/src/assets/styles/components/_filters.css
+++ b/src/assets/styles/components/_filters.css
@@ -7,6 +7,7 @@
     margin-block-end: 1.75rem;
 
     inclusive-disclosure {
+        padding-block-end: 1rem;
         padding-inline: 0;
     }
 
@@ -48,6 +49,7 @@
         position: absolute;
     }
 
+    inclusive-disclosure > button:focus::before, 
     inclusive-disclosure > button:hover::before {
         background-color: var(--fl-linkBgColor, var(--color-indigo-700));
     }


### PR DESCRIPTION
Add some padding-block-end to ensure spacing is maintained when the last filter option is focused. Also, resolve the issue where filter category icons disappear on focus in contrast themes.