### PR TITLE
fix: update resources i18n structure in the CMS

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -236,8 +236,9 @@ collections:
     label_singular: Resource
     name: resources
     icon: inventory_2
-    i18n: true
-    folder: src/collections/resources
+    i18n:
+      structure: multiple_folders
+    folder: src/collections/resources/
     slug: '{{uuid_short}}'
     extension: md
     create: true


### PR DESCRIPTION
This is an issue reported by @vr619536; resources were not shown properly in the CMS because of the i18n structure property.