### PR TITLE
fix: add a link to the resources page in ToC of All Standards project

### DIFF
--- a/src/_includes/layouts/project.njk
+++ b/src/_includes/layouts/project.njk
@@ -38,6 +38,7 @@
                         {% for subpage in subpages %}
                         <li><a href="{{ subpage.url }}">{{ subpage.title }}</a></li>
                         {% endfor %}
+                        <li><a href="/resources/?projects=e45a05ce-efb3-449f-965d-f671911b6626">{%  __ 'resources' %}</a></li>
                     </ul>
                 </li>
                 {% endif %}

--- a/src/_includes/partials/components/filters.njk
+++ b/src/_includes/partials/components/filters.njk
@@ -47,7 +47,7 @@
                 </inclusive-disclosure>
             </fieldset>
         {% endif %}
-        {% if filterableOptions.projects | length > 1 %}
+        {% if filterableOptions.projects | length > 0 %}
             <fieldset>
                 <legend class="visually-hidden">{% __ 'project' %}</legend>
                 <inclusive-disclosure>


### PR DESCRIPTION
Changes requested by @michelled and @uttaraghodke:

1. Show the project filter option in the resources page, even when there's only one project filter option available.
2. Add a link to the resources page with pre-selected project filter option from the All Standards project's ToC.
