### PR TITLE
feat: choose states from processes, use UUIDs for relationship stability

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -418,11 +418,16 @@ collections:
       default:
           field: order
           direction: ascending
+    slug: '{{fields._slug | localize}}'
     fields:
       - label: Title
         name: title
         widget: string
         i18n: true
+      - name: uuid
+        widget: hidden
+        default: '{{uuid_shorter}}'
+        i18n: duplicate
       - label: Draft
         name: draft
         widget: boolean
@@ -438,16 +443,6 @@ collections:
         widget: markdown
         i18n: true
         buttons: [bold, italic]
-      - label: Processes
-        name: processes
-        widget: relation
-        collection: processes
-        value_field: translationKey
-        search_fields: [title]
-        display_fields: [title]
-        required: false
-        multiple: true
-        i18n: duplicate
   - label: Processes
     label_singular: Process
     name: processes
@@ -467,11 +462,25 @@ collections:
         widget: string
         i18n: true
         required: false
+      - name: uuid
+        widget: hidden
+        default: {{uuid_shorter}}
+        i18n: duplicate
       - label: Draft
         name: draft
         widget: boolean
         i18n: duplicate
         required: false
+      - label: Stage
+        name: stage
+        widget: relation
+        collection: stages
+        value_field: uuid
+        search_fields: [title]
+        display_fields: [title]
+        required: true
+        multiple: false
+        i18n: duplicate
       - label: Body
         name: body
         widget: markdown
@@ -498,6 +507,10 @@ collections:
         name: title
         widget: string
         i18n: true
+      - name: uuid
+        widget: hidden
+        default: {{uuid_shorter}}
+        i18n: duplicate
       - label: Draft
         name: draft
         widget: boolean
@@ -528,6 +541,10 @@ collections:
         name: title
         widget: string
         i18n: true
+      - name: uuid
+        widget: hidden
+        default: {{uuid_shorter}}
+        i18n: duplicate
       - label: Draft
         name: draft
         widget: boolean
@@ -561,7 +578,7 @@ collections:
         name: processes
         widget: relation
         collection: processes
-        value_field: translationKey
+        value_field: uuid
         search_fields: [title]
         display_fields: [title]
         required: false
@@ -571,7 +588,7 @@ collections:
         name: barriers
         widget: relation
         collection: barriers
-        value_field: translationKey
+        value_field: uuid
         search_fields: [title]
         display_fields: [title]
         required: false

--- a/src/collections/stages/en/collectively-drafting-the-standard.md
+++ b/src/collections/stages/en/collectively-drafting-the-standard.md
@@ -1,5 +1,7 @@
 ---
+translationKey: collectively-drafting-the-standard
 title: Collectively drafting the standard
+uuid: 5871d856
 draft: false
 order: 4
 processes: []

--- a/src/collections/stages/en/organization-setup-and-strategies.md
+++ b/src/collections/stages/en/organization-setup-and-strategies.md
@@ -1,5 +1,7 @@
 ---
+translationKey: organization-setup-and-strategies
 title: Organization setup and strategies
+uuid: 2ac90c88
 draft: false
 order: 1
 processes: []

--- a/src/collections/stages/en/outreach-recruiting-and-registering-participants.md
+++ b/src/collections/stages/en/outreach-recruiting-and-registering-participants.md
@@ -1,5 +1,7 @@
 ---
+translationKey: outreach-recruiting-and-registering-participants
 title: Outreach, recruiting and registering participants
+uuid: b394d47d
 draft: false
 order: 2
 processes: []

--- a/src/collections/stages/en/preparing-for-participation.md
+++ b/src/collections/stages/en/preparing-for-participation.md
@@ -1,5 +1,7 @@
 ---
+translationKey: preparing-for-participation
 title: Preparing for participation
+uuid: 228cf07a
 draft: false
 order: 3
 processes: []

--- a/src/collections/stages/en/publishing-feedback-and-maintenance.md
+++ b/src/collections/stages/en/publishing-feedback-and-maintenance.md
@@ -1,5 +1,7 @@
 ---
+translationKey: publishing-feedback-and-maintenance
 title: Publishing, feedback and maintenance
+uuid: 8820ca59
 draft: false
 order: 5
 processes: []


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

As discussed, you now assign a Standards Development Process to a stage when editing the process, not vice versa. Additionally, relationships between barriers, strategies & tips, processes and stages use a hidden UUID field. The `translationKey` is mutable (e.g. if someone edits the English slug based on a title change, the `translationKey` gets updated). The UUID is set once on creation and is not editable via the CMS so the relationship cannot be accidentally broken by a content editor.

## Steps to test

1. Run locally.
2. Test creation and management of relationships between stages, processes, barriers, and strategies & tips.

**Expected behavior:** Relationships can be managed as expected. Changing the slug does not break the relationship.

## Additional information

_Not provided_

## Related issues

_Not provided_
