### PR TITLE
chore: remove version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
 	"packages": {
 		"": {
 			"name": "standards.idrc.ocadu.ca",
-			"version": "1.10.1",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@11ty/eleventy": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "standards.idrc.ocadu.ca",
-	"version": "1.10.1",
 	"description": "Website for IDRC standards development work.",
 	"main": "eleventy.config.js",
 	"type": "module",


### PR DESCRIPTION
We don't use release please so we don't need a semantic version in the package anymore.