### PR TITLE
fix: quote template strings

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -464,7 +464,7 @@ collections:
         required: false
       - name: uuid
         widget: hidden
-        default: {{uuid_shorter}}
+        default: '{{uuid_shorter}}'
         i18n: duplicate
       - label: Draft
         name: draft
@@ -509,7 +509,7 @@ collections:
         i18n: true
       - name: uuid
         widget: hidden
-        default: {{uuid_shorter}}
+        default: '{{uuid_shorter}}'
         i18n: duplicate
       - label: Draft
         name: draft
@@ -543,7 +543,7 @@ collections:
         i18n: true
       - name: uuid
         widget: hidden
-        default: {{uuid_shorter}}
+        default: '{{uuid_shorter}}'
         i18n: duplicate
       - label: Draft
         name: draft


### PR DESCRIPTION
The `{{uuid_shorter}}` strings for the hidden uuid widgets were missing quotes.