### PR TITLE
feat: use findAll filter to list related items on cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@11ty/eleventy-navigation": "^1.0.0",
 				"@11ty/font-awesome": "^1.0.1",
 				"@zachleat/filter-container": "greatislander/filter-container#feat/paginated-results",
-				"eleventy-plugin-fluid": "^3.1.6",
+				"eleventy-plugin-fluid": "^3.2.0",
 				"eleventy-plugin-footnotes": "^0.11.0",
 				"infusion": "^4.8.0",
 				"rimraf": "^6.0",
@@ -3217,9 +3217,9 @@
 			"license": "ISC"
 		},
 		"node_modules/eleventy-plugin-fluid": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/eleventy-plugin-fluid/-/eleventy-plugin-fluid-3.1.6.tgz",
-			"integrity": "sha512-wyoKmOvvaSlu544f7sMi1SctxaVjix2Z1r8AXpGb3Mx8fdPFl1Et8Umxz7WNBeUIqk/li7MT+IOeA91wFCJaMg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/eleventy-plugin-fluid/-/eleventy-plugin-fluid-3.2.0.tgz",
+			"integrity": "sha512-Kn/whgZQRmycU1lsD0XvsvBnG4KOV+kgc42f4/W15Jz7hRz4j9W8phJiADhR3KGJzjbem0Jjxly0AqVpFGvCig==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@11ty/eleventy-utils": "^2.0.0",
@@ -3228,6 +3228,7 @@
 				"fast-glob": "^3.3.3",
 				"html-minifier-terser": "^7.2.0",
 				"i18n-js": "^4.5.0",
+				"just-safe-get": "^4.2.0",
 				"lightningcss": "^1.26.0",
 				"rtl-detect": "^1.1.2"
 			},
@@ -4988,6 +4989,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/just-safe-get": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/just-safe-get/-/just-safe-get-4.2.0.tgz",
+			"integrity": "sha512-+tS4Bvgr/FnmYxOGbwziJ8I2BFk+cP1gQHm6rm7zo61w1SbxBwWGEq/Ryy9Gb6bvnloPq6pz7Bmm4a0rjTNlXA==",
+			"license": "MIT"
 		},
 		"node_modules/katex": {
 			"version": "0.16.28",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@11ty/eleventy-navigation": "^1.0.0",
 		"@11ty/font-awesome": "^1.0.1",
 		"@zachleat/filter-container": "greatislander/filter-container#feat/paginated-results",
-		"eleventy-plugin-fluid": "^3.1.6",
+		"eleventy-plugin-fluid": "^3.2.0",
 		"eleventy-plugin-footnotes": "^0.11.0",
 		"infusion": "^4.8.0",
 		"rimraf": "^6.0",

--- a/src/_includes/partials/components/card--barrier.njk
+++ b/src/_includes/partials/components/card--barrier.njk
@@ -9,7 +9,7 @@
             <div class="card__heading-image">
                 {% include 'svg/problem.svg' %}
                 <h4>
-                    {% __ 'barriers-problem' %} 
+                    {% __ 'barriers-problem' %}
                 </h4>
             </div>
             {{ barrier.data.problem | safe }}
@@ -18,14 +18,12 @@
             <div class="card__heading-image">
                 {% include 'svg/fix.svg' %}
                 <h4>
-                    {% __ 'barriers-fix' %} 
+                    {% __ 'barriers-fix' %}
                 </h4>
             </div>
             <ul>
-                {% for strategy in collections["strategies-and-tips_" + lang] %}
-                    {% if barrier.data.uuid in strategy.data.barriers %}
-                        <li>{{ strategy.data.title }}</li>
-                    {% endif %}
+                {% for strategy in collections["strategies-and-tips_" + lang] | findAll('data.barriers', barrier.data.uuid) %}
+                    <li>{{ strategy.data.title }}</li>
                 {% endfor %}
             </ul>
         {% endif %}

--- a/src/_includes/partials/components/card--strategies-and-tips.njk
+++ b/src/_includes/partials/components/card--strategies-and-tips.njk
@@ -9,7 +9,7 @@
             <div class="card__heading-image">
                 {% include 'svg/strategies.svg' %}
                 <h4>
-                    {% __ 'strategies-and-tips-strategies' %} 
+                    {% __ 'strategies-and-tips-strategies' %}
                 </h4>
             </div>
             {{ strategyOrTip.data.strategies | markdown | safe }}
@@ -33,10 +33,8 @@
 
             <ul>
                 {% for uuid in strategyOrTip.data.barriers %}
-                    {% for barrier in collections['barriers_' + lang] %}
-                        {% if barrier.data.uuid == uuid %}
-                            <li>{{ barrier.data.title }}</li>
-                        {% endif %}
+                    {% for barrier in collections['barriers_' + lang] | findAll('barrier.data.uuid', uuid) %}
+                        <li>{{ barrier.data.title }}</li>
                     {% endfor %}
                 {% endfor %}
             </ul>


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Uses the new `findAll` filter from [`eleventy-plugin-fluid`](https://github.com/fluid-project/eleventy-plugin-fluid) to show related items on barrier and strategies & tips cards.

## Steps to test

1. Add some barriers and strategies & tips using the CMS and link them.
2. Add barrier cards to the `barriers` layout.

**Expected behavior:** Related items show up as expected.

## Additional information

_Not provided_

## Related issues

_Not provided_