### PR TITLE
fix: enable highlights on result pages (resolves #390)

### DIFF
--- a/src/_includes/partials/global/scripts.njk
+++ b/src/_includes/partials/global/scripts.njk
@@ -6,3 +6,7 @@
 {% if translationKey == "search" %}
 <script type="text/javascript" src="/assets/scripts/search.js"></script>
 {% endif %}
+<script type="module">
+    await import('/pagefind/pagefind-highlight.js');
+    new PagefindHighlight({ highlightParam: "highlight" });
+</script>


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

See #390 for details.

## Steps to test

1. Go to /guidelines/search/?q=barrier
2. Navigate to any of the search result page
3. See the word "barrier" is highlighted
