### PR TITLE
fix: apply common sidebar nav style to the content class (resolves #403)

### DIFF
--- a/src/assets/styles/base/_base.css
+++ b/src/assets/styles/base/_base.css
@@ -76,6 +76,23 @@ body {
         min-width: 30rem;
         padding: unset;
     }
+
+    .content nav {
+        padding-inline: 8.4375rem 5rem;
+        position: relative;
+
+        &::after {
+            background-color: var(--fl-bgColor, var(--color-indigo-100));
+            content: "";
+            display: block;
+            height: 100%;
+            margin-inline-start: -100vw;
+            position: absolute;
+            top: 0;
+            width: 100vw;
+            z-index: -1;
+        }
+    }
 }
 
 /* Sections */

--- a/src/assets/styles/collections/_guidelines.css
+++ b/src/assets/styles/collections/_guidelines.css
@@ -350,26 +350,6 @@
     	margin-block-start: 7.5rem;
     }
 
-    .barrier nav,
-    .guidelines nav,
-    .process nav,
-    .strategy-tip nav {
-        padding-inline: 8.4375rem 5rem;
-        position: relative;
-
-        &::after {
-            background-color: var(--fl-bgColor, var(--color-indigo-100));
-            content: "";
-            display: block;
-            height: 100%;
-            margin-inline-start: -100vw;
-            position: absolute;
-            top: 0;
-            width: 100vw;
-            z-index: -1;
-        }
-    }
-
     .barrier article,
     .guidelines article,
     .process article,

--- a/src/assets/styles/collections/_projects.css
+++ b/src/assets/styles/collections/_projects.css
@@ -189,23 +189,6 @@
         padding-block: 8.4375rem;
     }
 
-    .project nav {
-        padding-inline: 8.4375rem 5rem;
-        position: relative;
-
-        &::after {
-            background-color: var(--fl-bgColor, var(--color-indigo-100));
-            content: "";
-            display: block;
-            height: 100%;
-            margin-inline-start: -100vw;
-            position: absolute;
-            top: 0;
-            width: 100vw;
-            z-index: -1;
-        }
-    }
-
     .project article {
         padding-inline: 8.4375rem;
     }

--- a/src/assets/styles/collections/_resources.css
+++ b/src/assets/styles/collections/_resources.css
@@ -113,23 +113,6 @@
         padding-block: 8.4375rem;
     }
 
-    .resource nav {
-        padding-inline: 8.4375rem 5rem;
-        position: relative;
-
-        &::after {
-            background-color: var(--fl-bgColor, var(--color-indigo-100));
-            content: "";
-            display: block;
-            height: 100%;
-            margin-inline-start: -100vw;
-            position: absolute;
-            top: 0;
-            width: 100vw;
-            z-index: -1;
-        }
-    }
-
     .resource article {
         padding-inline: 8.4375rem;
     }


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

See #403 for details.

## Steps to test

1. Go to a page where it has the page breadcrumb.
2. See there is no background going over to the left of the breadcrumb.

## Additional information

The after pseudo class was intended for the sidebar menu nav, but the previous selector was too broad that it applied to the banner nav as well.
