### PR TITLE
fix: generate nested TOC from h2-h3 headings (resolves #407, resolves #408)

### DIFF
--- a/src/_includes/layouts/process.njk
+++ b/src/_includes/layouts/process.njk
@@ -40,12 +40,6 @@
                         <h3>{% __ 'toc' %}</h3>
                     <ul role="list" class="flow"></ul>
                 </li>
-                <ul role="list" class="flow processes-strategies-and-tips">
-                        {% for strategyOrTip in strategiesOrTips %}
-                            <li><a href="#{{ strategyOrTip.data.title | slugify }}">{{ strategyOrTip.data.title }}</a></li>
-                        {% endfor %}
-                    </ul>
-                </li>
             </ul>
         </div>
     </inclusive-disclosure>

--- a/src/_includes/layouts/strategy-tip.njk
+++ b/src/_includes/layouts/strategy-tip.njk
@@ -55,11 +55,6 @@
                         <h3>{% __ 'toc' %}</h3>
                     <ul role="list" class="flow">
                     </ul>
-                <ul role="list" class="flow strategies-target-barriers">
-                        {% for barrier in targetBarriers %}
-                            <li><a href="#{{ barrier.data.title }}">{{ barrier.data.title }}</a></li>
-                        {% endfor %}
-                    </ul>
                 </li>
             </ul>
         </div>

--- a/src/_transforms/parse-transform.js
+++ b/src/_transforms/parse-transform.js
@@ -4,17 +4,38 @@ const parseTransform = (value, outputPath) => {
 	if (outputPath && outputPath.includes('.html')) {
 		const {document} = parseHTML(value);
 
-		const pageNavHeadings = document.querySelectorAll('main:has(nav) article h2');
-		if (pageNavHeadings.length > 0) {
-			const navContainer = document.querySelector('main nav #toc ul');
-			for (const heading of pageNavHeadings) {
-				if (heading.parentNode.tagName !== 'NAV') {
-					const link = document.createElement('a');
-					link.setAttribute('href', `#${heading.id}`);
-					link.innerHTML = heading.textContent;
-					const li = document.createElement('li');
-					li.append(link);
-					navContainer.append(li);
+		const pageNavHeadings = document.querySelectorAll('main:has(nav) article h2, main:has(nav) article h3');
+		const navContainer = document.querySelector('main nav #toc ul');
+		for (const heading of pageNavHeadings) {
+			const link = document.createElement('a');
+			link.setAttribute('href', `#${heading.id}`);
+			link.innerHTML = heading.textContent;
+			const li = document.createElement('li');
+			li.append(link);
+
+			if (heading.tagName === 'H2') {
+				li.dataset.level = '2';
+				navContainer.append(li);
+			}
+
+			if (heading.tagName === 'H3') {
+				li.dataset.level = '3';
+
+				/* Retrieve the last list item for an H2 */
+				const lastListItem = [...navContainer.querySelectorAll('li[data-level="2"]')].pop();
+
+				/* See if it contains an unordered list for nested H3s */
+				let subUl = lastListItem.querySelector('ul');
+
+				/* Add the H3 list item to the unordered list if it exists */
+				if (subUl) {
+					subUl.append(li);
+					/* Create a new unordered list containing the H3 list item and add it to the H2 list item. */
+				} else {
+					subUl = document.createElement('ul');
+					subUl.className = 'flow';
+					subUl.append(li);
+					lastListItem.append(subUl);
 				}
 			}
 		}

--- a/src/assets/styles/collections/_guidelines.css
+++ b/src/assets/styles/collections/_guidelines.css
@@ -70,6 +70,17 @@
     display: none;
 }
 
+.barrier nav ul ul,
+.guidelines nav ul ul,
+.process nav ul ul,
+.strategy-tip nav ul ul {
+    padding-inline-start: 1.25rem;
+
+    li {
+    	list-style-type: none;
+    }
+}
+
 .barrier inclusive-disclosure h3,
 .process inclusive-disclosure h3,
 .strategy-tip inclusive-disclosure h3 {
@@ -115,10 +126,6 @@
     right: var(--common-inline-padding);
 }
 
-.processes-strategies-and-tips,
-.strategies-target-barriers {
-    padding-inline-start: 1.25rem;
-}
 
 .strategy-tip .icon {
     margin-inline: 1rem;

--- a/src/assets/styles/components/_navigation.css
+++ b/src/assets/styles/components/_navigation.css
@@ -218,3 +218,7 @@ a[rel="home"] {
         }
     }
 }
+
+#toc ul ul {
+	margin-block-start: 1.25rem;
+}


### PR DESCRIPTION

* [ ] This pull request has been tested by running `npm run test` without errors
* [ ] This pull request has been built by running `npm run build` without errors
* [ ] This isn't a duplicate of an existing pull request

## Description

Adds TOC links for H3s in proper hierarchy of nested unordered lists.

## Steps to test

1. Visit a barrier, a process, and a strategy and tip single page.

**Expected behavior:** See cards in correct hierarchy in sidebar.

## Additional information

Not applicable.

## Related issues

Resolves #407, resolves #408.