### PR TITLE
feat: indicate external resources with icon (resolves #393)

### DIFF
--- a/src/_includes/partials/components/card--resource.njk
+++ b/src/_includes/partials/components/card--resource.njk
@@ -3,7 +3,7 @@
     <div class="card__content">
         <h3>
             <a class="card__title" href="{{ resource.data.link if resource.data.link else resource.url }}"{% if resource.data.link %} rel="external"{% endif %}>
-                {{ resource.data.title | safe }}
+                {{ resource.data.title | safe }} {% if resource.data.link %}<i class="fa-solid fa-arrow-up-right-from-square"></i>{% endif %}
             </a>
         </h3>
         {% if resource.data.author or resource.data.publisher %}

--- a/src/assets/styles/components/_card.css
+++ b/src/assets/styles/components/_card.css
@@ -138,6 +138,13 @@ body:not([class*="fl-theme"]),
     text-decoration: none;
 }
 
+.card__title svg {
+	height: 1em;
+	margin-bottom: -0.125em;
+	margin-left: 0.25em;
+	width: 1em;
+}
+
 .card__title:focus {
     background: none;
     box-shadow: none;
@@ -191,7 +198,7 @@ body:not([class*="fl-theme"]),
     stroke: currentcolor;
 }
 
-.card *:has(> svg) {
+.card div:has(> svg) {
     align-items: center;
     display: flex;
     gap: 0.75rem;


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Adds an icon to indicate resources which are on an external website.

## Steps to test

1. Visit resources page.

**Expected behavior:** Observe external icons for external resources.

## Additional information

Links don't open in new windows so this isn't indicated for screen reader users. I'm not sure if there should be an indication of external links for screen reader users.

## Related issues

Resolves #393.