### PR TITLE
fix: adjust filter column width to better support tablet breakpoints

### DIFF
--- a/src/assets/styles/components/_filters.css
+++ b/src/assets/styles/components/_filters.css
@@ -199,6 +199,14 @@ inclusive-disclosure:has(#filter-topic) > button::before,
     mask-image: url("/assets/images/topic.svg");
 }
 
+@media (width >= 46.625rem) {
+	filter-container {
+        display: grid;
+        gap: 1.875rem;
+        grid-template-columns: 33% 1fr;
+    }
+}
+
 @media (width >= 70.875rem) {
     filter-container {
         display: grid;


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Adjusts the filter width to better support tablet views.

## Steps to test

1. View resources and barriers at a mid-sized (tablet) breakpoint.

**Expected behavior:** Filters and cards are better distributed.

## Additional information

_Not provided._

## Related issues

Resolves #413.