### PR TITLE
fix: add appropriate padding to the projects banner

### DIFF
--- a/src/assets/styles/collections/_projects.css
+++ b/src/assets/styles/collections/_projects.css
@@ -85,6 +85,10 @@
 }
 
 @media (width >= 70.875rem) {
+	.project .banner .banner__content {
+  		padding-block-start: var(--common-block-padding);
+	}
+
     [class^="fl-theme"]:not(.fl-theme-prefsEditor-default) .project .banner {
         box-shadow:
             inset 0 0.1875rem 0 0 var(--fl-fgColor, transparent),


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

There was not enough padding at the top of project pags:

<img width="769" height="197" alt="Screenshot 2026-03-24 at 11 02 34 AM" src="https://github.com/user-attachments/assets/2b42409d-57e6-4f96-b271-80be42550724" />


## Steps to test

1. Visit a project page.

**Expected behavior:** Sufficient padding above breadcrumbs.

## Additional information

_Not provided._

## Related issues

_Not provided._
