### PR TITLE
fix: use correct icon (resolves #476)

### DIFF
--- a/src/_includes/layouts/barrier.njk
+++ b/src/_includes/layouts/barrier.njk
@@ -42,7 +42,7 @@
     </inclusive-disclosure>
 </nav>
 <article class="flow" data-pagefind-body>
-<h2>{% include "svg/barriers.svg" %}{% __ 'barriers-problem' %}</h2>
+<h2>{% include "svg/problem.svg" %}{% __ 'barriers-problem' %}</h2>
 {{ problem | renderContent('md') | safe }}
 {% if collections['actions_' + lang] | find('data.barriers', uuid) %}
 <h2>{% include "svg/fix.svg" %}{%  __ 'barriers-fix' %}</h2>


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

See #476 for details.