### PR TITLE
fix: resolve flex display issue in search highlights

### DIFF
--- a/src/assets/styles/collections/_guidelines.css
+++ b/src/assets/styles/collections/_guidelines.css
@@ -123,22 +123,17 @@
 	color: var(--fl-fgColor, var(--color-indigo-700));
 }
 
-.action a[rel~="external"] {
-	align-items: center;
-	display: flex;
-	gap: 0.5rem;
-	inline-size: fit-content;
-}
-
 .action a[rel~="external"]::after {
 	background-color: var(--fl-fgColor, black);
 	block-size: 1em;
 	content: "";
-	display: inline-flex;
+	display: inline-block;
 	inline-size: 1em;
+	margin-inline-start: 0.25em;
 	mask-image: url("/assets/images/external-link.svg");
 	mask-position: center;
 	mask-repeat: no-repeat;
+	vertical-align: middle;
 }
 
 .action h2,
@@ -210,7 +205,7 @@
 
 .term-definition {
 	break-inside: avoid-column;
-	
+
 	dd, dt {
 		display: inline;
 	}


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Resolves the issue seen [on this page](https://standards.inclusivedesign.ca/guidelines/actions/manage-access-conflicts/?highlight=access&highlight=conflict), where the addition of `<mark>` elements to highlight search results breaks flex display:

<img width="637" height="283" alt="Screenshot showing weirdly broken line of text: 'When
Access Needs Collide: An Interactive Discussion on Navigating Conflicting Access Needs in the Classroom'" src="https://github.com/user-attachments/assets/643494f7-e38b-4c0a-b00d-9415b310823e" />

## Steps to test

1. Visit the deploy preview: https://fix-highlight.inclusive-standards.pages.dev/guidelines/actions/manage-access-conflicts/?highlight=access&highlight=conflict

**Expected behavior:** Looks the way it's supposed to.

## Additional information

_Not provided_

## Related issues

_Not provided_
