### PR TITLE
fix: add font-variant-ligatures none to some elements

### DIFF
--- a/src/assets/styles/base/_typography.css
+++ b/src/assets/styles/base/_typography.css
@@ -4,6 +4,7 @@ h3,
 h4,
 h5 {
     font-family: var(--family-display);
+    font-variant-ligatures: none;
 }
 
 h1 {

--- a/src/assets/styles/components/_disclosure.css
+++ b/src/assets/styles/components/_disclosure.css
@@ -14,6 +14,7 @@ inclusive-disclosure [aria-expanded] {
     display: flex;
     font-family: var(--family-display);
     font-size: calc(var(--step-2) * var(--fl-enhance-font-size-factor, 1));
+    font-variant-ligatures: none;
     font-weight: var(--fl-enhance-font-weight, var(--font-weight-semibold));
     height: 5rem;
     padding-inline-end: 0.625rem;

--- a/src/assets/styles/components/_filters.css
+++ b/src/assets/styles/components/_filters.css
@@ -72,6 +72,7 @@
 		display: flex;
 		font-family: var(--family-display);
 		font-size: calc(var(--step-2) * var(--fl-enhance-font-size-factor, 1));
+		font-variant-ligatures: none;
 		font-weight: var(--fl-enhance-font-weight, var(--font-weight-semibold));
 		gap: 0.875rem;
 		height: 5rem;

--- a/src/assets/styles/components/_navigation.css
+++ b/src/assets/styles/components/_navigation.css
@@ -47,6 +47,7 @@ footer a[data-brand] {
     display: block;
     font-family: var(--family-display);
     font-size: calc(var(--fl-enhance-font-size-factor, 1) * clamp(1.125rem, 1.0179rem + 0.5357vw, 1.5rem));
+    font-variant-ligatures: none;
     font-weight: var(--fl-enhance-font-weight, var(--font-weight-medium));
     text-decoration: none;
     text-decoration: var(--fl-enhance-text-decoration);


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Font ligatures causing some text to look odd; remove ligatures for fonts used`font-family: var(--family-display);`.

## Steps to test

Go to /guidelines/actions/manage-access-conflicts/?highlight=access&highlight=conflict and see the title in the banner has no font ligatures applied.