### PR TITLE
fix: browse actions filter order (resolves #561)

### DIFF
--- a/src/_includes/partials/components/action-filters.njk
+++ b/src/_includes/partials/components/action-filters.njk
@@ -24,7 +24,7 @@
             <legend>{% include '../../../_includes/svg/stage.svg' %}{% __ 'stages' %}</legend>
             <div id="stages">
                 <ul id="filter-stage" class="stages">
-                    {% for stage in filterableOptions.stages %}
+                    {% for stage in filterableOptions.stages | sort(attribute="data.order") %}
                         <li>
                             <input type="checkbox" id="{{ stage.data.uuid }}" name="stage" value="{{ stage.data.uuid }}" data-filter-key="stages"/>
                             <label for="{{ stage.data.uuid }}">{{ stage.data.title }}</label>


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Change the browse actions filter order to follow the ones in processes page; see #561 for details.

## Steps to test

1. Go to /guidelines/actions/
2. See the filter on the left side follows the order described in the issue
