### PR TITLE
feat: update browse cards (resolves #567, #568 and #573)

### DIFF
--- a/src/_includes/partials/components/card--action.njk
+++ b/src/_includes/partials/components/card--action.njk
@@ -11,27 +11,14 @@
 {% set filterData = filterData | objectArrayPush("stages", relatedStageUuids) %}
 {% set filterData = filterData | objectArrayPush("processes", relatedProcessUuids) %}
 
-<div class="card action bg-indigo-700" data-filter-stages="{{ filterData.stages | join(',') }}" data-filter-processes="{{ filterData.processes | join(',') }}">
+<div class="card action" data-filter-stages="{{ filterData.stages | join(',') }}" data-filter-processes="{{ filterData.processes | join(',') }}">
+    <div class="card__fold"></div>
+    <div class="card__icon">{% include "svg/action.svg" %}</div>
     <div class="card__content">
         <h3>
             <a class="card__title" href="{{ action.url }}">
                 {{ action.data.title }}
             </a>
         </h3>
-        {% set processes = action.data.processes %}
-        <div class="action-processes {{ 'only-two' if processes | length == 2 }}">
-                {% __ 'action-for' %}
-            {% for processId in processes %}
-                {% if processes | length > 1 %}
-                {{ 'and' if loop.last }}
-                {% endif %}
-                {% set process = collections['processes_' + lang] | find('data.uuid', processId) %}
-                <span>{% include '../../../_includes/svg/' + process.data.translationKey + '.svg' %}
-                <b>{{ process.data.title }}</b></span>
-                {% if processes | length > 2 %}
-                {{ ',' if not loop.last }}
-                {% endif %}
-            {% endfor %}
-        </div>
     </div>
 </div>

--- a/src/_includes/partials/components/card--barrier.njk
+++ b/src/_includes/partials/components/card--barrier.njk
@@ -14,34 +14,14 @@
 {% set filterData = filterData | objectArrayPush("stages", relatedStageUuids) %}
 {% set filterData = filterData | objectArrayPush("processes", relatedProcessUuids) %}
 
-<div class="card barrier bg-indigo-700" data-filter-stages="{{ filterData.stages | join(',') }}" data-filter-processes="{{ filterData.processes | join(',') }}">
+<div class="card barrier" data-filter-stages="{{ filterData.stages | join(',') }}" data-filter-processes="{{ filterData.processes | join(',') }}">
+    <div class="card__fold"></div>
+    <div class="card__icon">{% include "svg/barrier.svg" %}</div>
     <div class="card__content">
         <h3>
             <a class="card__title" href="{{ barrier.url }}">
                 {{ barrier.data.title }}
             </a>
         </h3>
-        {% if barrier.data.problem %}
-            <div class="card__heading-image">
-                {% include 'svg/problem.svg' %}
-                <h4>
-                    {% __ 'barriers-problem' %}
-                </h4>
-            </div>
-            {{ barrier.data.problem | markdown | safe }}
-        {% endif %}
-        {% if collections["actions_" + lang] | find("data.barriers", barrier.data.uuid) | length > 0 %}
-            <div class="card__heading-image">
-                {% include 'svg/action.svg' %}
-                <h4>
-                    {% __ 'barriers-fix' %}
-                </h4>
-            </div>
-            <ul>
-                {% for action in collections["actions_" + lang] | findAll('data.barriers', barrier.data.uuid) %}
-                    <li>{{ action.data.title }}</li>
-                {% endfor %}
-            </ul>
-        {% endif %}
     </div>
 </div>

--- a/src/_includes/partials/components/card--process.njk
+++ b/src/_includes/partials/components/card--process.njk
@@ -1,5 +1,6 @@
 {% set stage = collections['stages_' + lang] | find('data.uuid', process.data.stage) %}
 <div class="card process bg-guidelines-stage-{{ stage.data.order }}" data-stage="{{ stage.data.order }}">
+    <div class="card__fold"></div>
 	<div class="card__content">
         <h3>
             <a class="card__title" href="{{ process.url }}">
@@ -10,6 +11,5 @@
             {{ process.data.description | safe }}
         </p>
 		{% include '../../../_includes/svg/' + process.data.translationKey + '.svg' %}
-    	{% include '../../../assets/images/chevron-right.svg' %}
 	</div>
 </div>

--- a/src/assets/styles/base/_base.css
+++ b/src/assets/styles/base/_base.css
@@ -17,7 +17,7 @@ body {
 .banner {
     background-color: var(--fl-bgColor, var(--color-indigo-700));
     border-block: 0.2rem solid var(--fl-fgColor, transparent);
-    color: var(--fl-fgColor, white);
+    color: var(--fl-fgColor, var(--color-white));
     padding-block: var(--common-block-padding);
     padding-inline: var(--common-inline-padding);
 }

--- a/src/assets/styles/base/_utils.css
+++ b/src/assets/styles/base/_utils.css
@@ -60,23 +60,23 @@
 }
 
 .bg-guidelines-stage-1 {
-	background-color: var(--fl-bgColor, var(--color-guidelines-red));
+    --color-stage: var(--color-guidelines-red);
 }
 
 .bg-guidelines-stage-2 {
-	background-color: var(--fl-bgColor, var(--color-guidelines-orange));
+	--color-stage: var(--fl-bgColor, var(--color-guidelines-orange));
 }
 
 .bg-guidelines-stage-3 {
-	background-color: var(--fl-bgColor, var(--color-guidelines-yellow));
+	--color-stage: var(--fl-bgColor, var(--color-guidelines-yellow));
 }
 
 .bg-guidelines-stage-4 {
-	background-color: var(--fl-bgColor, var(--color-guidelines-green));
+	--color-stage: var(--fl-bgColor, var(--color-guidelines-green));
 }
 
 .bg-guidelines-stage-5 {
-	background-color: var(--fl-bgColor, var(--color-guidelines-blue));
+	--color-stage: var(--fl-bgColor, var(--color-guidelines-blue));
 }
 
 .bg-guidelines-stage-1-light {

--- a/src/assets/styles/base/_utils.css
+++ b/src/assets/styles/base/_utils.css
@@ -31,12 +31,12 @@
 
 .bg-indigo-700 {
     background-color: var(--fl-bgColor, var(--color-indigo-700));
-    color: var(--fl-fgColor, white);
+    color: var(--fl-fgColor, var(--color-white));
 }
 
 .bg-indigo-800 {
     background-color: var(--fl-bgColor, var(--color-indigo-800));
-    color: var(--fl-fgColor, white);
+    color: var(--fl-fgColor, var(--color-white));
 }
 
 .bg-red {
@@ -101,7 +101,7 @@
 
 .bg-dark-grey {
     background-color: var(--fl-bgColor, var(--color-dark-grey));
-    color: var(--fl-fgColor, white);
+    color: var(--fl-fgColor, var(--color-white));
 }
 
 @media (width >= 40rem) {

--- a/src/assets/styles/collections/_guidelines.css
+++ b/src/assets/styles/collections/_guidelines.css
@@ -23,7 +23,7 @@
 
 .action .banner {
 	background-color: var(--fl-bgColor, var(--color-indigo-800));
-	color: var(--fl-fgColor, white);
+	color: var(--fl-fgColor, var(--color-white));
 }
 
 .barriers .banner h1 {
@@ -152,7 +152,7 @@
 }
 
 .action a[rel~="external"]::after {
-	background-color: var(--fl-fgColor, black);
+	background-color: var(--fl-fgColor, var(--color-black));
 	block-size: 1em;
 	content: "";
 	display: inline-block;
@@ -169,7 +169,7 @@
 	block-size: 3.5rem;
 	fill: var(--fl-fgColor, --color-black);
 	inline-size: 3.5rem;
-	stroke: var(--fl-fgColor, black);
+	stroke: var(--fl-fgColor, var(--color-black));
 }
 
 .action-processes {

--- a/src/assets/styles/collections/_guidelines.css
+++ b/src/assets/styles/collections/_guidelines.css
@@ -496,6 +496,13 @@
 			grid-template-columns: repeat(2, 1fr);
 		}
 	}
+
+	.actions-container .actions,
+	.barriers-container .barriers {
+		display: grid;
+		gap: calc(32 / 16 * 1rem);
+		grid-template-columns: repeat(2, 1fr);
+	}
 }
 
 @media (width >=70.875rem) {

--- a/src/assets/styles/components/_card.css
+++ b/src/assets/styles/components/_card.css
@@ -19,7 +19,7 @@
 
 .card.action,
 .card.barrier {
-    border: 1.5px solid var(--fl-fgColor, var(--color-indigo-700));
+    border: 0.125rem solid var(--fl-fgColor, var(--color-indigo-700));
     border-radius: 0.5rem;
     clip-path: polygon(2.5rem 0, 100% 0, 100% 100%, 0 100%, 0 2.5rem);
     padding: 1rem;
@@ -89,11 +89,7 @@
 }
 
 .card.barrier {
-    background-color: var(--fl-bgColor, var(--color-indigo-100));
-
-    .card__content {
-        background-color: var(--fl-bgColor, var(--color-indigo-100));
-    }
+    background-color: var(--fl-bgColor, white);
 
     .card__icon {
         background-color: var(--fl-bgColor, var(--color-indigo-200));

--- a/src/assets/styles/components/_card.css
+++ b/src/assets/styles/components/_card.css
@@ -19,7 +19,8 @@
 
 .content {
     .card.action,
-    .card.barrier {
+    .card.barrier,
+    .card.process {
         border: 0.125rem solid var(--fl-fgColor, var(--color-indigo-700));
         border-radius: 0.5rem;
         clip-path: polygon(2.5rem 0, 100% 0, 100% 100%, 0 100%, 0 2.5rem);
@@ -86,7 +87,7 @@
     }
 
     .card__icon {
-        background-color: var(--fl-fgColor, white);
+        background-color: var(--fl-fgColor, var(--color-white));
 
         svg {
             fill: var(--fl-bgColor, var(--color-black));
@@ -96,7 +97,7 @@
 }
 
 .card.barrier {
-    background-color: var(--fl-bgColor, white);
+    background-color: var(--fl-bgColor, var(--color-white));
 
     .card__icon {
         background-color: var(--fl-fgColor, var(--color-indigo-200));
@@ -105,6 +106,84 @@
             fill: var(--fl-bgColor, var(--color-black));
             margin-inline: 0.4rem 0;
         }
+    }
+}
+
+.card.process {
+    aspect-ratio: 373 / 330;
+    background-color: var(--fl-bgColor, var(--color-white));
+	padding-block-start: 0;
+	padding-inline-start: calc(13 / 16 * 1rem);
+
+    &.bg-guidelines-stage-1 {
+        border: 0.25rem solid var(--fl-bgColor, var(--color-guidelines-red));
+
+        .card__fold {
+            background-color: var(--fl-fgColor, var(--color-guidelines-red));
+        }
+
+        &:has(a:hover),
+        &:has(a:focus) {
+            box-shadow: 0 0 0 0.625rem var(--fl-fgColor, var(--color-guidelines-red)) inset;
+        }
+    }
+
+    &.bg-guidelines-stage-2 {
+        border: 0.25rem solid var(--fl-bgColor, var(--color-guidelines-orange));
+
+        .card__fold {
+            background-color: var(--fl-fgColor, var(--color-guidelines-orange));
+        }
+
+        &:has(a:hover),
+        &:has(a:focus) {
+            box-shadow: 0 0 0 0.625rem var(--fl-fgColor, var(--color-guidelines-orange)) inset;
+        }
+    }
+
+    &.bg-guidelines-stage-3 {
+        border: 0.25rem solid var(--fl-bgColor, var(--color-guidelines-yellow));
+
+        .card__fold {
+            background-color: var(--fl-fgColor, var(--color-guidelines-yellow));
+        }
+
+        &:has(a:hover),
+        &:has(a:focus) {
+            box-shadow: 0 0 0 0.625rem var(--fl-fgColor, var(--color-guidelines-yellow)) inset;
+        }
+    }
+
+    &.bg-guidelines-stage-4 {
+        border: 0.25rem solid var(--fl-bgColor, var(--color-guidelines-green));
+
+        .card__fold {
+            background-color: var(--fl-fgColor, var(--color-guidelines-green));
+        }
+
+        &:has(a:hover),
+        &:has(a:focus) {
+            box-shadow: 0 0 0 0.625rem var(--fl-fgColor, var(--color-guidelines-green)) inset;
+        }
+    }
+
+    &.bg-guidelines-stage-5 {
+        border: 0.25rem solid var(--fl-bgColor, var(--color-guidelines-blue));
+
+        .card__fold {
+            background-color: var(--fl-fgColor, var(--color-guidelines-blue));
+        }
+
+        &:has(a:hover),
+        &:has(a:focus) {
+            box-shadow: 0 0 0 0.625rem var(--fl-fgColor, var(--color-guidelines-blue)) inset;
+        }
+    }
+
+    .card__content {
+        align-items: flex-start;
+        background-color: transparent;
+        position: relative;
     }
 }
 
@@ -117,17 +196,6 @@
 .card:has(a:focus) {
     outline: 0.1875rem solid var(--fl-linkFgColor, var(--color-indigo-700));
     outline-offset: 0.4375rem;
-}
-
-.card.process {
-	aspect-ratio: 373 / 330;
-	padding-block-start: 0;
-	padding-inline-start: calc(13 / 16 * 1rem);
-}
-
-.card.process .card__content {
-	align-items: flex-start;
-	position: relative;
 }
 
 .card.process svg {
@@ -211,7 +279,7 @@ body:not([class*="fl-theme"]),
 }
 
 .card__content {
-    background-color: var(--fl-bgColor, white);
+    background-color: var(--fl-bgColor, var(--color-white));
     border: 0.1875rem solid var(--fl-linkFgColor, transparent);
     display: flex;
     flex-direction: column;

--- a/src/assets/styles/components/_card.css
+++ b/src/assets/styles/components/_card.css
@@ -2,7 +2,7 @@
     box-shadow:
         0 0.625rem 1.25rem 0 var(--shadow-light),
         inset 0 0 0 0.1875rem var(--fl-linkFgColor, transparent);
-    color: var(--fl-fgColor, black);
+    color: var(--fl-fgColor, var(--color-black));
     display: flex;
     flex-direction: column;
     inline-size: clamp(16.25rem, 23rem, 1fr);
@@ -17,63 +17,64 @@
     inline-size: 3.75rem;
 }
 
-.card.action,
-.card.barrier {
-    border: 0.125rem solid var(--fl-fgColor, var(--color-indigo-700));
-    border-radius: 0.5rem;
-    clip-path: polygon(2.5rem 0, 100% 0, 100% 100%, 0 100%, 0 2.5rem);
-    padding: 1rem;
-    position: relative;
+.content {
+    .card.action,
+    .card.barrier {
+        border: 0.125rem solid var(--fl-fgColor, var(--color-indigo-700));
+        border-radius: 0.5rem;
+        clip-path: polygon(2.5rem 0, 100% 0, 100% 100%, 0 100%, 0 2.5rem);
+        padding: 1rem;
+        position: relative;
 
-    .card__fold {
-        background-color: var(--fl-fgColor, var(--color-indigo-700));
-        height: 3rem;
-        left: -0.5rem;
-        position: absolute;
-        top: -0.5rem;
-        transform: rotate(20deg);
-        width: 2.5rem;
-    }
-
-    .card__icon {
-        border-radius: 50%;
-        height: 3rem;
-        position: absolute;
-        right: 1rem;
-        top: 1rem;
-        width: 3rem;
-
-        svg {
-            block-size: 2.2rem;
-            inline-size: 2.2rem;
-            margin-inline: 0.25rem 0;
+        .card__fold {
+            background-color: var(--fl-fgColor, var(--color-indigo-700));
+            height: 3rem;
+            left: -0.5rem;
+            position: absolute;
+            top: -0.5rem;
+            transform: rotate(20deg);
+            width: 2.5rem;
         }
-    }
 
-    .card__content {
-        border: unset;
-        padding-block: 3.5rem 2rem;
-    }
+        .card__icon {
+            border-radius: 50%;
+            height: 3rem;
+            position: absolute;
+            right: 1rem;
+            top: 1rem;
+            width: 3rem;
 
-    &::after {
-        background-color: var(--fl-fgColor, black);
-        block-size: 2rem;
-        bottom: 1rem;
-        content: "";
-        display: block;
-        inline-size: 2rem;
-        mask-image: url("/assets/images/chevron-right.svg");
-        mask-position: center;
-        mask-repeat: no-repeat;
-        mask-size: 1.5rem;
-        pointer-events: none;
-        position: absolute;
-        right: 1rem;
-    }
+            svg {
+                block-size: 2.2rem;
+                inline-size: 2.2rem;
+            }
+        }
 
-    &:has(a:hover),
-    &:has(a:focus) {
-        box-shadow: 0 0 0 0.625rem var(--fl-fgColor, var(--color-indigo-700)) inset !important;
+        .card__content {
+            border: unset;
+            padding-block: 3.5rem 2rem;
+        }
+
+        &::after {
+            background-color: var(--fl-fgColor, var(--color-black));
+            block-size: 2rem;
+            bottom: 1rem;
+            content: "";
+            display: block;
+            inline-size: 2rem;
+            mask-image: url("/assets/images/chevron-right.svg");
+            mask-position: center;
+            mask-repeat: no-repeat;
+            mask-size: 1.5rem;
+            pointer-events: none;
+            position: absolute;
+            right: 1rem;
+        }
+
+        &:has(a:hover),
+        &:has(a:focus) {
+            box-shadow: 0 0 0 0.625rem var(--fl-fgColor, var(--color-indigo-700)) inset;
+        }
     }
 }
 
@@ -85,7 +86,12 @@
     }
 
     .card__icon {
-        background-color: var(--fl-bgColor, white);
+        background-color: var(--fl-fgColor, white);
+
+        svg {
+            fill: var(--fl-bgColor, var(--color-black));
+            margin-inline: 0.25rem 0;
+        }
     }
 }
 
@@ -93,10 +99,11 @@
     background-color: var(--fl-bgColor, white);
 
     .card__icon {
-        background-color: var(--fl-bgColor, var(--color-indigo-200));
+        background-color: var(--fl-fgColor, var(--color-indigo-200));
 
         svg {
-            margin-inline-start: 0.4rem;
+            fill: var(--fl-bgColor, var(--color-black));
+            margin-inline: 0.4rem 0;
         }
     }
 }
@@ -214,7 +221,7 @@ body:not([class*="fl-theme"]),
 }
 
 .card__title {
-    color: var(--fl-linkFgColor, black);
+    color: var(--fl-linkFgColor, var(--color-black));
     font-family: var(--family-sans-serif);
     font-size: inherit;
     font-weight: var(--font-weight-semibold);

--- a/src/assets/styles/components/_card.css
+++ b/src/assets/styles/components/_card.css
@@ -107,10 +107,10 @@
     }
 
     .card__icon {
-        background-color: var(--fl-fgColor, var(--color-white));
+        background-color: var(--fl-linkFgColor, var(--color-white));
 
         svg {
-            fill: var(--fl-bgColor, var(--color-black));
+            fill: var(--fl-linkBgColor, var(--color-black));
             margin-inline: 0.25rem 0;
         }
     }
@@ -120,10 +120,10 @@
     background-color: var(--fl-bgColor, var(--color-white));
 
     .card__icon {
-        background-color: var(--fl-fgColor, var(--color-indigo-200));
+        background-color: var(--fl-linkFgColor, var(--color-indigo-200));
 
         svg {
-            fill: var(--fl-bgColor, var(--color-black));
+            fill: var(--fl-linkBgColor, var(--color-black));
             margin-inline: 0.4rem 0;
         }
     }

--- a/src/assets/styles/components/_card.css
+++ b/src/assets/styles/components/_card.css
@@ -21,14 +21,14 @@
     .card.action,
     .card.barrier,
     .card.process {
-        border: 0.125rem solid var(--fl-fgColor, var(--color-indigo-700));
+        border: 0.125rem solid var(--fl-linkFgColor, var(--color-indigo-700));
         border-radius: 0.5rem;
         clip-path: polygon(2.5rem 0, 100% 0, 100% 100%, 0 100%, 0 2.5rem);
         padding: 1rem;
         position: relative;
 
         .card__fold {
-            background-color: var(--fl-fgColor, var(--color-indigo-700));
+            background-color: var(--fl-linkFgColor, var(--color-indigo-700));
             height: 3rem;
             left: -0.5rem;
             position: absolute;
@@ -57,16 +57,16 @@
         }
 
         &::after {
-            background-color: var(--fl-fgColor, var(--color-black));
-            block-size: 2rem;
+            background-color: var(--fl-linkFgColor, var(--color-black));
+            block-size: calc(2rem * (1 + var(--fl-enhance-font-size-factor, 0)));
             bottom: 1rem;
             content: "";
             display: block;
-            inline-size: 2rem;
+            inline-size: calc(2rem * (1 + var(--fl-enhance-font-size-factor, 0)));
             mask-image: url("/assets/images/chevron-right.svg");
             mask-position: center;
             mask-repeat: no-repeat;
-            mask-size: 1.5rem;
+            mask-size: calc(1.5rem * (1 + var(--fl-enhance-font-size-factor, 0)));
             pointer-events: none;
             position: absolute;
             right: 1rem;
@@ -74,7 +74,27 @@
 
         &:has(a:hover),
         &:has(a:focus) {
-            box-shadow: 0 0 0 0.625rem var(--fl-fgColor, var(--color-indigo-700)) inset;
+            box-shadow: 0 0 0 0.625rem var(--fl-linkFgColor, var(--color-indigo-700)) inset;
+        }
+    }
+
+    .card.process {
+        background-color: var(--fl-bgColor, var(--color-white));
+        border: 0.25rem solid var(--fl-linkFgColor, var(--color-stage));
+
+        .card__fold {
+            background-color: var(--fl-linkFgColor, var(--color-stage));
+        }
+
+        &:has(a:hover),
+        &:has(a:focus) {
+            box-shadow: 0 0 0 0.625rem var(--fl-linkFgColor, var(--color-stage)) inset;
+        }
+
+        .card__content {
+            align-items: flex-start;
+            background-color: transparent;
+            position: relative;
         }
     }
 }
@@ -106,84 +126,6 @@
             fill: var(--fl-bgColor, var(--color-black));
             margin-inline: 0.4rem 0;
         }
-    }
-}
-
-.card.process {
-    aspect-ratio: 373 / 330;
-    background-color: var(--fl-bgColor, var(--color-white));
-	padding-block-start: 0;
-	padding-inline-start: calc(13 / 16 * 1rem);
-
-    &.bg-guidelines-stage-1 {
-        border: 0.25rem solid var(--fl-bgColor, var(--color-guidelines-red));
-
-        .card__fold {
-            background-color: var(--fl-fgColor, var(--color-guidelines-red));
-        }
-
-        &:has(a:hover),
-        &:has(a:focus) {
-            box-shadow: 0 0 0 0.625rem var(--fl-fgColor, var(--color-guidelines-red)) inset;
-        }
-    }
-
-    &.bg-guidelines-stage-2 {
-        border: 0.25rem solid var(--fl-bgColor, var(--color-guidelines-orange));
-
-        .card__fold {
-            background-color: var(--fl-fgColor, var(--color-guidelines-orange));
-        }
-
-        &:has(a:hover),
-        &:has(a:focus) {
-            box-shadow: 0 0 0 0.625rem var(--fl-fgColor, var(--color-guidelines-orange)) inset;
-        }
-    }
-
-    &.bg-guidelines-stage-3 {
-        border: 0.25rem solid var(--fl-bgColor, var(--color-guidelines-yellow));
-
-        .card__fold {
-            background-color: var(--fl-fgColor, var(--color-guidelines-yellow));
-        }
-
-        &:has(a:hover),
-        &:has(a:focus) {
-            box-shadow: 0 0 0 0.625rem var(--fl-fgColor, var(--color-guidelines-yellow)) inset;
-        }
-    }
-
-    &.bg-guidelines-stage-4 {
-        border: 0.25rem solid var(--fl-bgColor, var(--color-guidelines-green));
-
-        .card__fold {
-            background-color: var(--fl-fgColor, var(--color-guidelines-green));
-        }
-
-        &:has(a:hover),
-        &:has(a:focus) {
-            box-shadow: 0 0 0 0.625rem var(--fl-fgColor, var(--color-guidelines-green)) inset;
-        }
-    }
-
-    &.bg-guidelines-stage-5 {
-        border: 0.25rem solid var(--fl-bgColor, var(--color-guidelines-blue));
-
-        .card__fold {
-            background-color: var(--fl-fgColor, var(--color-guidelines-blue));
-        }
-
-        &:has(a:hover),
-        &:has(a:focus) {
-            box-shadow: 0 0 0 0.625rem var(--fl-fgColor, var(--color-guidelines-blue)) inset;
-        }
-    }
-
-    .card__content {
-        align-items: flex-start;
-        background-color: transparent;
-        position: relative;
     }
 }
 
@@ -289,12 +231,12 @@ body:not([class*="fl-theme"]),
 }
 
 .card__title {
-    color: var(--fl-linkFgColor, var(--color-black));
+    color: var(--fl-linkFgColor, currentColor);
     font-family: var(--family-sans-serif);
-    font-size: inherit;
-    font-weight: var(--font-weight-semibold);
+    font-size: var(--fl-enhance-font-size);
+    font-weight: var(--fl-enhance-font-weight, var(--font-weight-semibold));
     margin: 0;
-    text-decoration: none;
+    text-decoration: var(--fl-enhance-text-decoration, none);
 }
 
 .card__title svg {

--- a/src/assets/styles/components/_card.css
+++ b/src/assets/styles/components/_card.css
@@ -17,10 +17,91 @@
     inline-size: 3.75rem;
 }
 
-.card.actions,
+.card.action,
 .card.barrier {
-    padding-block-start: unset;
-    padding-inline-start: 0.8125rem;
+    border: 1.5px solid var(--fl-fgColor, var(--color-indigo-700));
+    border-radius: 0.5rem;
+    clip-path: polygon(2.5rem 0, 100% 0, 100% 100%, 0 100%, 0 2.5rem);
+    padding: 1rem;
+    position: relative;
+
+    .card__fold {
+        background-color: var(--fl-fgColor, var(--color-indigo-700));
+        height: 3rem;
+        left: -0.5rem;
+        position: absolute;
+        top: -0.5rem;
+        transform: rotate(20deg);
+        width: 2.5rem;
+    }
+
+    .card__icon {
+        border-radius: 50%;
+        height: 3rem;
+        position: absolute;
+        right: 1rem;
+        top: 1rem;
+        width: 3rem;
+
+        svg {
+            block-size: 2.2rem;
+            inline-size: 2.2rem;
+            margin-inline: 0.25rem 0;
+        }
+    }
+
+    .card__content {
+        border: unset;
+        padding-block: 3.5rem 2rem;
+    }
+
+    &::after {
+        background-color: var(--fl-fgColor, black);
+        block-size: 2rem;
+        bottom: 1rem;
+        content: "";
+        display: block;
+        inline-size: 2rem;
+        mask-image: url("/assets/images/chevron-right.svg");
+        mask-position: center;
+        mask-repeat: no-repeat;
+        mask-size: 1.5rem;
+        position: absolute;
+        right: 1rem;
+    }
+
+    &:has(a:hover),
+    &:has(a:focus) {
+        box-shadow: 0 0 0 0.625rem var(--fl-fgColor, var(--color-indigo-700)) inset !important;
+    }
+}
+
+.card.action {
+    background-color: var(--fl-bgColor, var(--color-indigo-200));
+
+    .card__content {
+        background-color: var(--fl-bgColor, var(--color-indigo-200));
+    }
+
+    .card__icon {
+        background-color: var(--fl-bgColor, white);
+    }
+}
+
+.card.barrier {
+    background-color: var(--fl-bgColor, var(--color-indigo-100));
+
+    .card__content {
+        background-color: var(--fl-bgColor, var(--color-indigo-100));
+    }
+
+    .card__icon {
+        background-color: var(--fl-bgColor, var(--color-indigo-200));
+
+        svg {
+            margin-inline-start: 0.4rem;
+        }
+    }
 }
 
 .resources .card {

--- a/src/assets/styles/components/_card.css
+++ b/src/assets/styles/components/_card.css
@@ -66,6 +66,7 @@
         mask-position: center;
         mask-repeat: no-repeat;
         mask-size: 1.5rem;
+        pointer-events: none;
         position: absolute;
         right: 1rem;
     }

--- a/src/assets/styles/components/_filters.css
+++ b/src/assets/styles/components/_filters.css
@@ -209,6 +209,13 @@ inclusive-disclosure:has(#filter-topic)>button::before,
 		gap: 1.875rem;
 		grid-template-columns: 33% 1fr;
 	}
+
+	.actions,
+	.barriers {
+		filter-container {
+			display: block;
+		}
+	}
 }
 
 @media (width >=70.875rem) {
@@ -216,5 +223,13 @@ inclusive-disclosure:has(#filter-topic)>button::before,
 		display: grid;
 		gap: 1.875rem;
 		grid-template-columns: 22.9375rem 1fr;
+	}
+
+	.actions,
+	.barriers {
+		filter-container {
+			display: grid;
+			grid-template-columns: 25% 1fr;
+		}
 	}
 }

--- a/src/assets/styles/components/_filters.css
+++ b/src/assets/styles/components/_filters.css
@@ -68,7 +68,7 @@
 
 	.filters legend {
 		align-items: center;
-		box-shadow: inset 0 .125rem 0 0 var(--fl-linkFgColor, var(--color-indigo-700));
+		border-top: 0.125rem solid var(--fl-linkFgColor, var(--color-indigo-700));
 		display: flex;
 		font-family: var(--family-display);
 		font-size: calc(var(--step-2) * var(--fl-enhance-font-size-factor, 1));

--- a/src/assets/styles/components/_project-panel.css
+++ b/src/assets/styles/components/_project-panel.css
@@ -55,7 +55,6 @@ body:not([class*="fl-theme"]),
 }
 
 .project-panel__title {
-    color: black;
     font-family: var(--family-sans-serif);
     font-size: var(--step-4);
     font-weight: var(--font-weight-semibold);
@@ -66,7 +65,7 @@ body:not([class*="fl-theme"]),
 .project-panel__title:focus {
     background: none;
     box-shadow: none;
-    color: var(--fl-linkFgColor, var(--black));
+    color: var(--fl-linkFgColor, var(--color-black));
     outline: none;
 }
 
@@ -78,7 +77,7 @@ body:not([class*="fl-theme"]),
 }
 
 .project-panel__content {
-    background-color: var(--fl-bgColor, white);
+    background-color: var(--fl-bgColor, var(--color-white));
     border: 0.1875rem solid var(--fl-linkFgColor, transparent);
     display: flex;
     flex-direction: column;

--- a/src/assets/styles/global/_footer.css
+++ b/src/assets/styles/global/_footer.css
@@ -36,7 +36,7 @@ footer section a {
 }
 
 footer svg {
-    fill: var(--fl-linkFgColor, white);
+    fill: var(--fl-linkFgColor, var(--color-white));
 }
 
 footer a:hover svg {


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Update browse by pages' card based on new design. See #567, #568 and #573 for details, and update the layout to be two column layout until the screen size shrinks to small device.

## Steps to test

1. Go to /guidelines/actions/ and see that the card design follows #567 
2. Go to /guidelines/barries/ and see that the card design follows #568
3. Go to /guidelines/processes/ and see that the card design follows #573 
