### PR TITLE
fix: processes page background issue on enhanced input

### DIFF
--- a/src/assets/styles/collections/_guidelines.css
+++ b/src/assets/styles/collections/_guidelines.css
@@ -97,7 +97,8 @@
 	background-size: cover;
 }
 
-[class^="fl-theme"]:not(.fl-theme-prefsEditor-default) .processes {
+[class^="fl-theme"]:not(.fl-theme-prefsEditor-default) .processes,
+[class^="fl-input-enhanced"]:not(.fl-theme-prefsEditor-default) .processes {
 	background-image: none;
 }
 


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Fix the issue with processes page have background in contrast themes with enhanced input on.

## Steps to test

1. Go to /guidelines/processes/.
2. Turn on the enhanced input mode from the UIO.
3. Change to different contrast themes and see that the background image is not there in the contrast themes.