### PR TITLE
fix: resources page card icons

### DIFF
--- a/src/assets/styles/collections/_resources.css
+++ b/src/assets/styles/collections/_resources.css
@@ -19,6 +19,11 @@
     margin-block-start: 1em;
 }
 
+.resources .card svg{
+    fill: none;
+    stroke: currentcolor;
+}
+
 .resource .banner {
     background-color: var(--fl-bgColor, var(--color-indigo-200));
     color: var(--fl-fgColor, var(--color-black));


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Fixes issue on resources page where the icons used in card were not appearing properly.

## Steps to test

1. Go to /resources/ page
2. Check the icons on cards are appearing as expectd